### PR TITLE
Use asm_syscall (..., SYS_close) for close () on Epiphany.

### DIFF
--- a/libgloss/epiphany/close.c
+++ b/libgloss/epiphany/close.c
@@ -51,6 +51,6 @@ extern int  errno;
 int __attribute__ ((section ("libgloss_epiphany")))
 _close (int  fildes)
 {
-  return  asm_close (fildes);
+  return asm_syscall (fildes, NULL, NULL, SYS_close);
 
 }	/* _close () */


### PR DESCRIPTION
As documented in Adapteva's architecture reference manual.
